### PR TITLE
Revert "fix author name"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ profile = "black"
 name = "tfl-training-sbi"
 version = "0.1.0"
 description = ""
-authors = ["Maternus Herold, Jan Boelts (Teusen)"]
+authors = ["Maternus Herold, Jan Boelts"]
 packages = [
     { include = "tfl_training_sbi", from = "src" },
 ]


### PR DESCRIPTION
Reverts aai-institute/tfl-training-sbi#28

Reverting as we don't need this change and it introduces merge conflicts. 